### PR TITLE
Added title prefix option. Prefix is attached to titles in all windows.

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,13 +1,3 @@
-function restoreWindowTitles() {
-  browser.windows.getAll((windows) => {
-    windows.map(window => window.id).forEach((windowId) => {
-      browser.sessions.getWindowValue(windowId, 'title').then((title) => {
-        if (title) browser.windows.update(windowId, { titlePreface: title });
-      });
-    });
-  });
-}
-
 // Needs to listen in case the user restores windows by clicking the restore button in the session
 // manager window.
 // http://kb.mozillazine.org/Browser.sessionstore.max_resumed_crashes
@@ -16,6 +6,10 @@ function restoreWindowTitles() {
 // to this one instead.
 browser.tabs.onCreated.addListener(() => {
   restoreWindowTitles();
+});
+
+browser.windows.onCreated.addListener((window) => {
+  restoreWindowTitle(window);
 });
 
 // Needs to run if the session is restored automatically, without the session manager window.

--- a/lib.js
+++ b/lib.js
@@ -1,0 +1,28 @@
+function computeTitle(title) {
+  const getting = browser.storage.sync.get({
+    prefix: '',
+    prefixGlue: '',
+  });
+
+  return getting.then((result) => {
+    const computedTitle = result.prefix
+      + (result.prefix && title && result.prefixGlue)
+      + (title || '');
+
+    return computedTitle ? `[${computedTitle}] ` : '';
+  });
+}
+
+function setWindowTitle(windowId) {
+  return browser.sessions.getWindowValue(windowId, 'title')
+    .catch(() => '')
+    .then(title => computeTitle(title))
+    .then(computedTitle => browser.windows.update(windowId, { titlePreface: computedTitle }));
+}
+
+function restoreWindowTitles() {
+  return browser.windows.getAll((windows) => {
+    windows.map(window => window.id)
+      .forEach(setWindowTitle);
+  });
+}

--- a/lib.js
+++ b/lib.js
@@ -6,7 +6,7 @@ function computeTitle(title) {
 
   return getting.then((result) => {
     const computedTitle = result.prefix
-      + (result.prefix && title && result.prefixGlue)
+      + ((result.prefix && title && result.prefixGlue) || '')
       + (title || '');
 
     return computedTitle ? `[${computedTitle}] ` : '';

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,11 @@
       "id": "{35dd5f9a-ca89-4643-b107-f07d09cc94b5}"
     }
   },
+  "options_ui": {
+    "page": "options/options.html",
+    "browser_style": true,
+    "chrome_style": true
+  },
   "browser_action": {
     "default_title": "Window Titler (Ctrl+Alt+T)",
     "default_popup": "popup.html",
@@ -73,10 +78,12 @@
     "256": "icons/dark/icon-256.png"
   },
   "permissions": [
-    "sessions"
+    "sessions",
+    "storage"
   ],
   "background": {
     "scripts": [
+      "lib.js",
       "background.js"
     ]
   }

--- a/options/options.css
+++ b/options/options.css
@@ -1,0 +1,12 @@
+form#titler_options {
+    display: table;
+}
+form#titler_options > * {
+    display: table-row;
+}
+form#titler_options > * > * {
+    display: table-cell;
+}
+form#titler_options > * > *:first-child {
+    padding-right: 1em;
+}

--- a/options/options.html
+++ b/options/options.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <link rel="stylesheet" href="options.css">
+</head>
+
+<body>
+    <form id="titler_options">
+        <span><label>Prefix </label><input type="text" id="titler_prefix"/></span>
+        <span><label>Prefix glue </label><input type="text" id="titler_prefix_glue"/></span>
+        <span><button type="submit">Save</button><button type="button" id="titler_defaults">Defaults</button></span>
+    </form>
+
+    <script src="../lib.js"></script>
+    <script src="options.js"></script>
+</body>
+</html>

--- a/options/options.js
+++ b/options/options.js
@@ -1,0 +1,35 @@
+const DEFAULT_PREFIX = '';
+const DEFAULT_PREFIX_GLUE = ' - ';
+
+function saveOptions(e) {
+  e.preventDefault();
+  return browser.storage.sync.set({
+    prefix: document.querySelector('#titler_prefix').value,
+    prefixGlue: document.querySelector('#titler_prefix_glue').value,
+  })
+    .then(() => restoreWindowTitles());
+}
+
+function setCurrentChoice(result) {
+  document.querySelector('#titler_prefix').value = result.prefix;
+  document.querySelector('#titler_prefix_glue').value = result.prefixGlue;
+}
+
+function restoreDefaults() {
+  setCurrentChoice({
+    prefix: DEFAULT_PREFIX,
+    prefixGlue: DEFAULT_PREFIX_GLUE,
+  });
+}
+
+function restoreOptions() {
+  const getting = browser.storage.sync.get({
+    prefix: DEFAULT_PREFIX,
+    prefixGlue: DEFAULT_PREFIX_GLUE,
+  });
+  return getting.then(setCurrentChoice);
+}
+
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.querySelector('form').addEventListener('submit', saveOptions);
+document.querySelector('#titler_defaults').addEventListener('click', restoreDefaults);

--- a/popup.html
+++ b/popup.html
@@ -12,6 +12,7 @@
 		<input class="form-control" id="title-input" type="text" autofocus/>
 		<input class="btn btn-default" id="set-window-title-prefix" type="submit" value="OK" />
 	</form>
+	<script src="lib.js"></script>
 	<script src="popup.js"></script>
 </body>
 

--- a/popup.js
+++ b/popup.js
@@ -1,9 +1,9 @@
-function setTitle(title) {
-  const computedTitle = title ? `[${title}] ` : '';
+async function setTitle(title) {
+  const currentWindow = await window.browser.windows.getCurrent();
 
-  return window.browser.windows.getCurrent().then(currentWindow => Promise.all([
-    browser.windows.update(currentWindow.id, { titlePreface: computedTitle }),
-    browser.sessions.setWindowValue(currentWindow.id, 'title', computedTitle)]));
+  await browser.sessions.setWindowValue(currentWindow.id, 'title', title);
+
+  return setWindowTitle(currentWindow.id);
 }
 
 document.getElementById('window-title-prefix-form').addEventListener('submit', async (e) => {


### PR DESCRIPTION
Hi, thanks a lot for your plugin. I use it to distinct firefox windows of different profiles. The problem was that it was necessary to define separate titles for all new windows. Therefore I added prefix option which is attached to all windows. It solved the problem without changing original functionality. If you'll find the solution useful for your plugin feel free to merge :)